### PR TITLE
Fix/21: Config location import fallback

### DIFF
--- a/dist/regal-bundler.cjs.js
+++ b/dist/regal-bundler.cjs.js
@@ -74,6 +74,8 @@ const metadataKeys = [
     "homepage",
     "repository"
 ];
+/* Wrapper for dynamic imports so that they can be mocked during tests. */
+const importDynamic = (s) => Promise.resolve(require(s));
 /**
  * Loads user configuration, searching in `regal.json` and the
  * `regal` property in `package.json`.
@@ -95,7 +97,20 @@ const loadUserConfig = (configLocation) => __awaiter(undefined, void 0, void 0, 
         config.game = {};
     }
     const pkgPath = path.join(configLocation, "package.json");
-    const pkg = yield Promise.resolve(require(pkgPath));
+    let pkg;
+    try {
+        pkg = yield importDynamic(pkgPath);
+    }
+    catch (ex1) {
+        // If configLocation can't be resolved, attempt to resolve it
+        // relative to the current working directory.
+        try {
+            pkg = yield importDynamic(path.join(process.cwd(), pkgPath));
+        }
+        catch (ex2) {
+            throw new regal.RegalError(`Could not resolve configLocation at ${pkgPath}`);
+        }
+    }
     const metadata = config.game;
     for (const mk of metadataKeys) {
         if (metadata[mk] === undefined && pkg[mk] !== undefined) {

--- a/dist/src/get-config.d.ts
+++ b/dist/src/get-config.d.ts
@@ -1,5 +1,6 @@
 import { LoadedConfiguration } from "./interfaces-internal";
 import { BundlerOptions, RecursivePartial } from "./interfaces-public";
+export declare const importDynamic: (s: string) => Promise<any>;
 /**
  * Loads user configuration, searching in `regal.json` and the
  * `regal` property in `package.json`.


### PR DESCRIPTION
## Description
* Adds a fallback to `loadUserConfig`, which attempts to resolve the `configLocation` path relative to `process.cwd()` if importing fails on the first attempt. 
* If it fails on the second attempt, a more descriptive error will throw.
* Adds a wrapper function for dynamic imports in `get-config` to make them easier to test.
* Keeps unit test coverage at 100%.

## Related Issues
* Fixes #21 