### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # regal-bundler Changelog
 
+## v1.2.0 (2019-03-08)
+
+### Dependency Changes
+* Change `typescript` from a dev dependency to a direct dependency ([0594c24](https://github.com/regal/regal-bundler/commit/0594c24f661b00c434571b8ab82f01a2bb51422b)), fixes [#26](https://github.com/regal/regal-bundler/issues/26)
+* Change `regal` from a direct dependency to a peer dependency ([7943714](https://github.com/regal/regal-bundler/commit/79437148319203158d542627deef04cf5c8a5204)), resolves [#27](https://github.com/regal/regal-bundler/issues/27)
+
 ## v1.1.0 (2019-02-16)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The module format of the bundle. Options: `cjs`, `esm`, `umd`. Defaults to `cjs`
 
 #### `bundler.output.minify`: boolean
 
-Whether minification should be done on the bundle after it's generated. Defaults to true.
+Whether minification should be done on the bundle after it's generated. Defaults to false.
 
 ### Bundles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6774,10 +6774,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
-      "dev": true
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw=="
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5054,7 +5054,8 @@
     "prando": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/prando/-/prando-5.1.0.tgz",
-      "integrity": "sha512-UkXcaSqEoMz2S5O/uhb9emINjP1qM9vClszDSPCIVhI7s696tVCNS5qbm5b7qSwMlpLS3rih4NHFZdPzwHTtSQ=="
+      "integrity": "sha512-UkXcaSqEoMz2S5O/uhb9emINjP1qM9vClszDSPCIVhI7s696tVCNS5qbm5b7qSwMlpLS3rih4NHFZdPzwHTtSQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -5271,6 +5272,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regal/-/regal-1.0.0.tgz",
       "integrity": "sha512-Xyy8/OfiA/w+ZdA+Wt7pjxow7dRQSmHcXMoWkdGS9Rh9lnBKcWGgjcYuDm4mapYRctbrdseeJyYGNFmq5yCsTw==",
+      "dev": true,
       "requires": {
         "prando": "^5.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regal-bundler",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regal-bundler",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Utility that packages a Regal game into a deployable game bundle",
   "author": "Joe Cowman <joe.r.cowman@gmail.com> (http://joecowman.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@sindresorhus/slugify": "^0.6.0",
     "cosmiconfig": "^5.0.7",
     "path": "^0.12.7",
-    "regal": "^1.0.0",
     "rollup": "^0.67.4",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-insert": "^0.2.0",
@@ -53,6 +52,9 @@
     "sanitize-filename": "^1.6.1",
     "typescript": "^3.3.3333"
   },
+  "peerDependencies": {
+    "regal": "^1.0.0"
+  },
   "devDependencies": {
     "@types/cosmiconfig": "^5.0.3",
     "@types/jest": "^23.3.10",
@@ -61,6 +63,7 @@
     "cz-conventional-changelog": "^2.1.0",
     "jest": "^23.6.0",
     "prettier": "^1.15.3",
+    "regal": "^1.0.0",
     "rollup-plugin-cleanup": "^3.1.0",
     "trash-cli": "^1.4.0",
     "ts-jest": "^23.10.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "rollup-plugin-terser": "^3.0.0",
     "rollup-plugin-typescript2": "^0.18.0",
     "rollup-plugin-virtual": "^1.0.1",
-    "sanitize-filename": "^1.6.1"
+    "sanitize-filename": "^1.6.1",
+    "typescript": "^3.3.3333"
   },
   "devDependencies": {
     "@types/cosmiconfig": "^5.0.3",
@@ -65,8 +66,7 @@
     "ts-jest": "^23.10.5",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.17.0",
-    "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.2.2"
+    "tslint-plugin-prettier": "^2.0.1"
   },
   "prettier": {
     "tabWidth": 4


### PR DESCRIPTION
## v1.2.0 (2019-03-08)

### Dependency Changes
* Change `typescript` from a dev dependency to a direct dependency ([0594c24](https://github.com/regal/regal-bundler/commit/0594c24f661b00c434571b8ab82f01a2bb51422b)), fixes [#26](https://github.com/regal/regal-bundler/issues/26)
* Change `regal` from a direct dependency to a peer dependency ([7943714](https://github.com/regal/regal-bundler/commit/79437148319203158d542627deef04cf5c8a5204)), resolves [#27](https://github.com/regal/regal-bundler/issues/27)