### PR TITLE
Add gameVersion to the bundle header, if the property exists

### DIFF
--- a/dist/regal-bundler.cjs.js
+++ b/dist/regal-bundler.cjs.js
@@ -273,7 +273,7 @@ const makeBundler = (config) => {
  * @param config The loaded configuration.
  */
 const bundleHeader = (config) => `/** 
-* ${config.game.name}
+* ${config.game.name} ${config.game.gameVersion !== undefined ? config.game.gameVersion : ""}
 * by ${config.game.author}
 *
 * Powered by the Regal Framework (https://github.com/regal/regal).

--- a/dist/regal-bundler.esm.js
+++ b/dist/regal-bundler.esm.js
@@ -270,7 +270,7 @@ const makeBundler = (config) => {
  * @param config The loaded configuration.
  */
 const bundleHeader = (config) => `/** 
-* ${config.game.name}
+* ${config.game.name} ${config.game.gameVersion !== undefined ? config.game.gameVersion : ""}
 * by ${config.game.author}
 *
 * Powered by the Regal Framework (https://github.com/regal/regal).

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -99,7 +99,9 @@ export const makeBundler = (config: LoadedConfiguration) => {
  * @param config The loaded configuration.
  */
 export const bundleHeader = (config: LoadedConfiguration) => `/** 
-* ${config.game.name}
+* ${config.game.name} ${
+    config.game.gameVersion !== undefined ? config.game.gameVersion : ""
+}
 * by ${config.game.author}
 *
 * Powered by the Regal Framework (https://github.com/regal/regal).

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -18,7 +18,8 @@ jest.mock("../../src/get-config");
 const sampleConfig = () => ({
     game: {
         name: "My Cool Game",
-        author: "Joe Cowman"
+        author: "Joe Cowman",
+        gameVersion: "1.0.0"
     },
     bundler: {
         input: {
@@ -222,6 +223,22 @@ describe("Bundle", () => {
             const bundle = standardBundle(Game) as any;
             expect(bundle.init).toBeUndefined;
             expect(bundle.reset).toBeUndefined;
+        });
+    });
+
+    describe("Code injections", () => {
+        it("bundleHeader includes the version number if it's provided", () => {
+            const config = sampleConfig();
+            expect(
+                bundleHeader(config).includes(config.game.gameVersion)
+            ).toBeTruthy();
+        });
+
+        it("bundleHeader does not include the version number if it's undefined", () => {
+            const config = sampleConfig();
+            config.game.gameVersion = undefined;
+
+            expect(bundleHeader(config).includes("undefined")).toBeFalsy();
         });
     });
 });


### PR DESCRIPTION
## Description
* Adds the value of `gameVersion`, if defined, to bundle headers

## Checklist
### Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor (changes code but not behavior)
- [ ] Non-code Change (documentation, dependencies, etc.)

#### Is this a breaking change?
- [x] No 
- [ ] Yes

*If yes, describe what exactly this change breaks:*

### Unit Tests
- [x] Tests Added
- [ ] Tests Modified
- [ ] No Change

### Documentation
- [ ] In-code Docs
- [ ] API Reference
- [ ] Other (*Specify:* )
- [x] No Change

### Related Issues
Issue Number | Action | Notes
--- | --- | ---

### Further Action
Description | Issue Number
--- | ---
